### PR TITLE
AWSVIYA-194 Update repo to handle SAS Orchestration CLI changes

### DIFF
--- a/ansible/playbooks/dataprep2dataagent.yml
+++ b/ansible/playbooks/dataprep2dataagent.yml
@@ -69,7 +69,7 @@
       - "sas-viya-dagentcont-default"
       - "sas-viya-dagentmgmt-default"
 
-- hosts: [sas-casserver-primary]
+- hosts: [sas-casserver-primary, sas_casserver_primary]
   gather_facts: False
   become: yes
   become_user: sas

--- a/scripts/download_file_tree.sh
+++ b/scripts/download_file_tree.sh
@@ -57,7 +57,7 @@ pushd $DOWNLOAD_DIR
    find $DIRS -type d | xargs chmod 700
    find $DIRS -type f | xargs chmod 600
    # make all scripts files executable and for owner only
-   find $DIRS -name *.sh | xargs chmod 700
+   find $DIRS -name "*.sh" | xargs chmod 700
 
 
 popd

--- a/scripts/process_overrides.sh
+++ b/scripts/process_overrides.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+#
+# process overrides
+#
+# Allow for overrides of common code and orchestration CLI URLs. This is most useful for testing
+# common code and orchestration changes that are not yet in production.
+#
+# To override the common code URL:
+#    Add a file named "common_code.sh" to the root S3 folder containing the quickstart.
+#    This file should have a single line of the form:
+#
+#       COMMON_CODE_BRANCH=<git branch name>
+#
+#    Where <git branch name> is the name of the branch in the GitHub common code repository to be used
+#    by the deployment.
+#
+# To override the SAS Orchestration CLI URL:
+#    Add a file named "group_vars.yaml" to the root S3 folder containing the quickstart.
+#    This file should have a single line of the form:
+#
+#      SAS_ORCHESTRATION_CLI_URL: "<orchestration url>"
+#
+#    Where <orchestration url> is a URL pointing to the sas-orchestration-linux.tgz file to be used
+#    by the deployment. *This URL must be accessible to the quickstart running in the AWS cloud - i.e. it
+#    can't be a location on the SAS intranet.
+
+# Check for common code url override file - if this file exists, open it to get the correct
+# common code tag
+pushd /sas/install
+COMMON_CODE_OVERRIDE="common_code.sh"
+if [ -f "$COMMON_CODE_OVERRIDE" ]; then
+    source "$COMMON_CODE_OVERRIDE"
+    if [[ -n $COMMON_CODE_BRANCH ]]; then
+	rm -Rf common
+	git clone https://github.com/sassoftware/quickstart-sas-viya-common.git common
+	pushd common &&  git checkout $COMMON_CODE_BRANCH && rm -rf .git* && popd
+	RC=$?
+
+	if [ ! $RC = 0 ]; then
+	    echo "ERROR: Common code branch $COMMON_CODE_BRANCH cannot be checked out"
+	    exit $RC
+	fi
+    fi
+fi
+   
+# Check for ansible group_var override file - if this file exists, copy it to
+# the common/ansible/playbooks/group_vars folder to override variables defined in
+# all.yaml
+GROUP_VAR_OVERRIDE="group_vars.yaml"
+if [[ -f "$GROUP_VAR_OVERRIDE" ]]; then
+    cp $GROUP_VAR_OVERRIDE common/ansible/playbooks/group_vars/AnsibleController.yml
+    RC=$?
+
+    if [ ! $RC = 0 ]; then
+	echo "ERROR: group_vars.yaml override file cannot be processed."
+	exit $RC
+    fi
+fi
+popd

--- a/scripts/process_overrides.sh
+++ b/scripts/process_overrides.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+EC2_AVAIL_ZONE=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone)
+EC2_REGION=$(echo ${EC2_AVAIL_ZONE}  | sed "s/[a-z]$//")
+
 #
 # process overrides
 #
@@ -7,13 +10,17 @@
 # common code and orchestration changes that are not yet in production.
 #
 # To override the common code URL:
-#    Add a file named "common_code.sh" to the root S3 folder containing the quickstart.
-#    This file should have a single line of the form:
+#    Add a file named "git_overrides.sh" to the root S3 folder containing the quickstart.
+#    This file can contain the following variables have a single line of the form:
 #
 #       COMMON_CODE_BRANCH=<git branch name>
+#       VIYA_ARK_URL=<s3 location for Viya Ark>
 #
-#    Where <git branch name> is the name of the branch in the GitHub common code repository to be used
-#    by the deployment.
+#    Where :
+#       <git branch name> is the name of the branch in the GitHub common code repository to be used
+#          by the deployment.
+#       <s3 location for Viya Ark> is the s3 URL pointing to a Viya Ark folder in S3 (to be used when testing
+#          a Viya Ark change that is not yet publicly available from GitHub)
 #
 # To override the SAS Orchestration CLI URL:
 #    Add a file named "group_vars.yaml" to the root S3 folder containing the quickstart.
@@ -27,10 +34,12 @@
 
 # Check for common code url override file - if this file exists, open it to get the correct
 # common code tag
+INSTALL_USER=$(whoami)
+
 pushd /sas/install
-COMMON_CODE_OVERRIDE="common_code.sh"
-if [ -f "$COMMON_CODE_OVERRIDE" ]; then
-    source "$COMMON_CODE_OVERRIDE"
+GIT_OVERRIDE="git_overrides.sh"
+if [ -f "$GIT_OVERRIDE" ]; then
+    source "$GIT_OVERRIDE"
     if [[ -n $COMMON_CODE_BRANCH ]]; then
 	rm -Rf common
 	git clone https://github.com/sassoftware/quickstart-sas-viya-common.git common
@@ -41,6 +50,21 @@ if [ -f "$COMMON_CODE_OVERRIDE" ]; then
 	    echo "ERROR: Common code branch $COMMON_CODE_BRANCH cannot be checked out"
 	    exit $RC
 	fi
+	echo "Overriding common code branch with branch: $COMMON_CODE_BRANCH"
+    fi
+    if [[ -n $VIYA_ARK_URL ]]; then
+	VIRK_DIR="/sas/install/ansible/sas_viya_playbook/viya-ark"
+	rm -Rf $VIRK_DIR
+	aws --region ${EC2_REGION} s3 sync $VIYA_ARK_URL $VIRK_DIR
+	chown -R ${INSTALL_USER}:${INSTALL_USER} ansible
+	
+	RC=$?
+	
+	if [ ! $RC = 0 ]; then
+	    echo "ERROR: Could not override Viya Ark with $VIYA_ARK_URL"
+	    exit $RC
+	fi
+	echo "Overriding Viya Ark location with $VIYA_ARK_URL"
     fi
 fi
    
@@ -56,5 +80,6 @@ if [[ -f "$GROUP_VAR_OVERRIDE" ]]; then
 	echo "ERROR: group_vars.yaml override file cannot be processed."
 	exit $RC
     fi
+    echo "Overriding group vars"
 fi
 popd

--- a/templates/sas-viya.template.yaml
+++ b/templates/sas-viya.template.yaml
@@ -1171,7 +1171,9 @@ Resources:
           commands:
             01-setup:
               command: !Sub
-                - su -l ec2-user -c 'NFS_SERVER=${ANSIBLE_CONTROLLER_IP} HOST=services /tmp/prereqs.sh &>/tmp/prereqs.log'
+                - |
+                  #!/bin/bash -e
+                  su -l ec2-user -c 'NFS_SERVER=${ANSIBLE_CONTROLLER_IP} HOST=services /tmp/prereqs.sh &>/tmp/prereqs.log'
                 - ANSIBLE_CONTROLLER_IP: !GetAtt AnsibleController.PrivateIp
     Properties:
       KeyName: !Ref KeyPairName
@@ -1207,7 +1209,7 @@ Resources:
       UserData:
         Fn::Base64:
           Fn::Sub: |
-            #!/bin/bash
+            #!/bin/bash -e
             export PATH=$PATH:/usr/local/bin
             curl -O https://bootstrap.pypa.io/get-pip.py && python get-pip.py &> /dev/null
             pip install awscli --ignore-installed six &> /dev/null
@@ -1250,7 +1252,9 @@ Resources:
           commands:
             01-setup:
               command: !Sub
-                - su -l ec2-user -c 'NFS_SERVER=${ANSIBLE_CONTROLLER_IP} HOST=controller /tmp/prereqs.sh &>/tmp/prereqs.log'
+                - |
+                  #!/bin/bash -e
+                  su -l ec2-user -c 'NFS_SERVER=${ANSIBLE_CONTROLLER_IP} HOST=controller /tmp/prereqs.sh &>/tmp/prereqs.log'
                 - ANSIBLE_CONTROLLER_IP: !GetAtt AnsibleController.PrivateIp
     Properties:
       KeyName: !Ref KeyPairName
@@ -1273,7 +1277,7 @@ Resources:
       UserData:
         Fn::Base64:
           Fn::Sub: |
-            #!/bin/bash
+            #!/bin/bash -e
             export PATH=$PATH:/usr/local/bin
             curl -O https://bootstrap.pypa.io/get-pip.py && python get-pip.py &> /dev/null
             pip install awscli --ignore-installed six &> /dev/null
@@ -1602,10 +1606,14 @@ Resources:
         configSets:
           bootstrap:
             - bootstrap
+          fileprep:
+            - fileprep  
           predeployment:
             - predeployment
           deployment:
             - deployment
+          postdeployment:
+            - postdeployment
         bootstrap:
           files:
             /tmp/prereqs.sh:
@@ -1631,14 +1639,17 @@ Resources:
               group: root
               authentication: S3AccessCreds
 
+
           commands:
             01-bastion_bootstrap:
-              command: /tmp/bastion_bootstrap.sh --enable false
-            02-ansible_prereqs:
-              command: su -l ec2-user -c '/tmp/prereqs.sh &>/tmp/prereqs.log'
-
-
-        predeployment:
+              command: |
+                #!/bin/bash -e
+                /tmp/bastion_bootstrap.sh --enable false
+            02-ansible_prereqs: 
+              command: |
+                #!/bin/bash -e
+                su -l ec2-user -c '/tmp/prereqs.sh &>/tmp/prereqs.log'
+        fileprep:
           files:
             /tmp/cloudwatch.conf:
               source: !Sub
@@ -1719,14 +1730,12 @@ Resources:
                   "Ref": SASUserPass
                 SASAdminPass: !Base64
                   "Ref": SASAdminPass
-
           commands:
             01-download_file_tree:
               command: !Sub
                 - |
+                  #!/bin/bash -e
                   su -l ec2-user -c '
-                    #!/bin/bash
-                    set -e
                     # download the project files into /sas/install
                     FILE_ROOT=${S3_FILE_ROOT} /tmp/download_file_tree.sh &>/tmp/download_file_tree.log
                     # update any mustache parms
@@ -1736,33 +1745,35 @@ Resources:
                     update_parms /sas/install/scripts/recover_cascontroller.sh &>>/tmp/update_parms.log
                   '
                 - S3_FILE_ROOT: !Sub "${QSS3BucketName}/${QSS3KeyPrefix}"
-                  
             02-process_overrides:
               command: !Sub |
                 FAILMSG=$(/sas/install/scripts/process_overrides.sh)
                 export RC=$?; export FAILMSG
                 [ ! $RC = 0 ] && /sas/install/scripts/send_sns_message.sh failure
                 exit $RC
-
             03-validate_parms:
               command: !Sub |
-                FAILMSG=$(/sas/install/scripts/validate_parameters.sh)
+                #!/bin/bash -e
+                FAILMSG="$(/sas/install/scripts/validate_parameters.sh)"
                 export RC=$?; export FAILMSG
                 [ ! $RC = 0 ] && /sas/install/scripts/send_sns_message.sh failure
                 exit $RC
-
-            04-send_start_message:
-              command: /sas/install/scripts/send_sns_message.sh starting
-
-            05-cloudwatch:
-              command: >-
+            04-cloudwatch:
+              command: |
+                #!/bin/bash -e
                 sed -i 's/{instance_id}/ansible-controller-commands.log/' /etc/awslogs/awslogs.conf;
                 cat /tmp/cloudwatch.conf >> /etc/awslogs/awslogs.conf;
                 service awslogs restart
-
-            06-nodeprep:
+            05-send_start_message:
+              command: |
+                 #!/bin/bash -e
+                 /sas/install/scripts/send_sns_message.sh starting
+        predeployment:
+          commands:
+            01-nodeprep:
               command: !Sub
                 - |
+                  #!/bin/bash -e
                   su -l ec2-user -c '
                     export ANSIBLE_LOG_PATH=/var/log/sas/install/prepare_nodes.log
                     export ANSIBLE_CONFIG=/sas/install/common/ansible/playbooks/ansible.cfg
@@ -1775,9 +1786,10 @@ Resources:
                    - IsNotI3
                    - '-e "CASCACHE_DISK=/dev/sdd"'
                    - ''
-            07-openldap:
+            02-openldap:
               command: !Sub
                 - |
+                  #!/bin/bash -e
                   if [ -n "${ADMINPASS}" ] && [ -n "${USERPASS}" ]; then
                     su -l ec2-user -c '
                       export ANSIBLE_LOG_PATH=/var/log/sas/install/openldap.log
@@ -1797,6 +1809,7 @@ Resources:
             01-orchestration:
               command: !Sub
                 - |
+                  #!/bin/bash -e
                   su -l ec2-user -c '
                     export ANSIBLE_LOG_PATH=/var/log/sas/install/prepare_deployment.log
                     export ANSIBLE_CONFIG=/sas/install/common/ansible/playbooks/ansible.cfg
@@ -1813,6 +1826,7 @@ Resources:
 
             02-virk:
               command: |
+                #!/bin/bash -e
                 su -l ec2-user -c '
                   export ANSIBLE_LOG_PATH=/var/log/sas/install/virk.log
                   export ANSIBLE_CONFIG=/sas/install/common/ansible/playbooks/ansible.cfg
@@ -1823,6 +1837,7 @@ Resources:
                 '
             03-install:
               command: |
+                #!/bin/bash -e
                 su -l ec2-user -c '
                   export ANSIBLE_LOG_PATH=/var/log/sas/install/viya_deployment.log
                   pushd /sas/install/ansible/sas_viya_playbook
@@ -1830,15 +1845,19 @@ Resources:
                   RC=1
                   until [ $count -gt 3 ]; do ansible-playbook site.yml && RC=0 && break || let count=count+1; done
                 '
-            04-post-install:
+        postdeployment:
+          commands:
+            01-post-install:
               command: |
+                #!/bin/bash -e
                 su -l ec2-user -c '
                   export ANSIBLE_LOG_PATH=/var/log/sas/install/post_deployment.log
                   export ANSIBLE_CONFIG=/sas/install/common/ansible/playbooks/ansible.cfg
                   ansible-playbook -v /sas/install/common/ansible/playbooks/post_deployment.yml
                 '
-            05-post-install-02:
+            02-post-install-02:
               command: !Sub |
+                #!/bin/bash -e
                 su -l ec2-user -c '
                   export ANSIBLE_LOG_PATH=/var/log/sas/install/post_deployment.log
                   export ANSIBLE_CONFIG=/sas/install/common/ansible/playbooks/ansible.cfg
@@ -1863,7 +1882,27 @@ Resources:
       UserData:
         Fn::Base64:
           Fn::Sub: |
-            #!/bin/bash
+            #!/bin/bash -e
+
+            trap term EXIT
+
+            MSG_SCRIPT=/sas/install/scripts/send_sns_message.sh 
+            FAILMSG=
+
+            function term {
+              RC=$?
+              if [ $RC = 0 ]; then
+                [ -x $MSG_SCRIPT ] && $MSG_SCRIPT success
+              else
+                [ -x $MSG_SCRIPT ] && RC=$RC FAILMSG=$FAILMSG $MSG_SCRIPT failure
+              fi              
+
+              # update the StackComplete WaitCondition (this concludes the Stack creation)
+              cfn-signal -e $RC --stack ${AWS::StackName} --resource StackComplete --region ${AWS::Region}
+
+              exit $RC
+            }    
+
             export PATH=$PATH:/usr/local/bin:/opt/aws/bin
             pip install awscli --ignore-installed six &> /dev/null
             # remove pre-installed cfn bootstrap utilities
@@ -1877,39 +1916,40 @@ Resources:
             # Install prereqs
             #
             cfn-init --stack ${AWS::StackName} --resource AnsibleController --configsets bootstrap --region ${AWS::Region}
-            RC=$?
+            
+            #
             # This signal will complete the ansible controller creation and allow the other VMs to start
             # their creation, using the ansible controller private ip as input
             #
+            RC=$?
             cfn-signal -e $RC --stack ${AWS::StackName} --resource AnsibleController --region ${AWS::Region}
             if ! [ $RC = 0 ]; then
               exit $RC
             fi
 
             #
+            # file preparation
+            #
+            cfn-init --stack ${AWS::StackName} --resource AnsibleController --configsets fileprep --region ${AWS::Region}
+
+            #
             # environment preparation
             #
+            FAILMSG="ERROR: Pre-deployment steps failed." 
             cfn-init --stack ${AWS::StackName} --resource AnsibleController --configsets predeployment --region ${AWS::Region}
-            RC=$?
-            # If something goes wrong here, we do not need to continue
-            if ! [ $RC = 0 ]; then
-              RC=$RC FAILMSG="ERROR: Predeployment failed on ansible controller" /sas/install/scripts/send_sns_message.sh failure
-              cfn-signal -e $RC --success false --stack ${AWS::StackName} --resource StackComplete --region ${AWS::Region}
-              exit 1
-            fi
-
+          
             #
             # Start the actual Viya deployment
             #
+            FAILMSG="ERROR: Main Viya deployment failed."
             cfn-init --stack ${AWS::StackName} --resource AnsibleController --configsets deployment --region ${AWS::Region}
-            RC=$?
-            # update the StackComplete WaitCondition (this concludes the Stack creation)
-            if [ $RC = 0 ]; then
-              /sas/install/scripts/send_sns_message.sh success
-            else
-              RC=$RC /sas/install/scripts/send_sns_message.sh failure
-            fi
-            cfn-signal -e $RC --stack ${AWS::StackName} --resource StackComplete --region ${AWS::Region}
+
+            #
+            # Post deployment steps
+            #
+            FAILMSG="ERROR: Post-deployment steps failed."
+            cfn-init --stack ${AWS::StackName} --resource AnsibleController --configsets postdeployment --region ${AWS::Region}
+
 Outputs:
   SASDrive:
     Description: SAS Viya launch page for SAS solutions and SAS Environment Manager

--- a/templates/sas-viya.template.yaml
+++ b/templates/sas-viya.template.yaml
@@ -1747,10 +1747,13 @@ Resources:
                 - S3_FILE_ROOT: !Sub "${QSS3BucketName}/${QSS3KeyPrefix}"
             02-process_overrides:
               command: !Sub |
-                FAILMSG=$(/sas/install/scripts/process_overrides.sh)
-                export RC=$?; export FAILMSG
-                [ ! $RC = 0 ] && /sas/install/scripts/send_sns_message.sh failure
-                exit $RC
+                #!/bin/bash -e
+                su -l ec2-user -c '
+                  FAILMSG=$(/sas/install/scripts/process_overrides.sh)
+                  export RC=$?; export FAILMSG
+                  [ ! $RC = 0 ] && /sas/install/scripts/send_sns_message.sh failure
+                  exit $RC
+                '
             03-validate_parms:
               command: !Sub |
                 #!/bin/bash -e

--- a/templates/sas-viya.template.yaml
+++ b/templates/sas-viya.template.yaml
@@ -1737,24 +1737,30 @@ Resources:
                   '
                 - S3_FILE_ROOT: !Sub "${QSS3BucketName}/${QSS3KeyPrefix}"
                   
+            02-process_overrides:
+              command: !Sub |
+                FAILMSG=$(/sas/install/scripts/process_overrides.sh)
+                export RC=$?; export FAILMSG
+                [ ! $RC = 0 ] && /sas/install/scripts/send_sns_message.sh failure
+                exit $RC
 
-            02-validate_parms:
+            03-validate_parms:
               command: !Sub |
                 FAILMSG=$(/sas/install/scripts/validate_parameters.sh)
                 export RC=$?; export FAILMSG
                 [ ! $RC = 0 ] && /sas/install/scripts/send_sns_message.sh failure
                 exit $RC
 
-            03-send_start_message:
+            04-send_start_message:
               command: /sas/install/scripts/send_sns_message.sh starting
 
-            04-cloudwatch:
+            05-cloudwatch:
               command: >-
                 sed -i 's/{instance_id}/ansible-controller-commands.log/' /etc/awslogs/awslogs.conf;
                 cat /tmp/cloudwatch.conf >> /etc/awslogs/awslogs.conf;
                 service awslogs restart
 
-            05-nodeprep:
+            06-nodeprep:
               command: !Sub
                 - |
                   su -l ec2-user -c '
@@ -1769,7 +1775,7 @@ Resources:
                    - IsNotI3
                    - '-e "CASCACHE_DISK=/dev/sdd"'
                    - ''
-            06-openldap:
+            07-openldap:
               command: !Sub
                 - |
                   if [ -n "${ADMINPASS}" ] && [ -n "${USERPASS}" ]; then


### PR DESCRIPTION
This commit updates this repo to handle SAS Orchestration CLI changes, along with the associated changes to viya-ark. Hyphenated ansible group names are no longer supported, so all hyphenated group names have been changed to underscored group names.

Additionally, this commit adds the ability to override:
- The quickstart-sas-viya-common branch from which the common code is pulled
- The location from which the orchestration cli .tgz file is retrieved
- The location from which the viya-ark code is retrieved

See scripts/process_overrides.sh for more details on this ability.