### PR TITLE
(AWSVIYA-197) Limit load balancer to only SAS recommended cipher suites

### DIFF
--- a/ansible/roles/post_deployment/configure_cert/tasks/main.yml
+++ b/ansible/roles/post_deployment/configure_cert/tasks/main.yml
@@ -101,6 +101,6 @@
     do
       sleep 1
     done
-    aws --region {{AWS_REGION}} elb set-load-balancer-policies-of-listener --load-balancer-name "{{ELB_NAME}}" --load-balancer-port 443 --policy-names AppCookieStickinessPolicy
+    aws --region {{AWS_REGION}} elb set-load-balancer-policies-of-listener --load-balancer-name "{{ELB_NAME}}" --load-balancer-port 443 --policy-names '["AppCookieStickinessPolicy" ,"SASRestrictedSSL"]'
 
 

--- a/templates/sas-viya.template.yaml
+++ b/templates/sas-viya.template.yaml
@@ -1018,6 +1018,20 @@ Resources:
       AppCookieStickinessPolicy:
         - CookieName: dummy
           PolicyName: AppCookieStickinessPolicy
+      Policies:
+        - Attributes:
+            - Name: Protocol-TLSv1.2
+              Value: True
+            - Name: ECDHE-ECDSA-AES128-GCM-SHA256
+              Value: True
+            - Name: ECDHE-RSA-AES128-GCM-SHA256
+              Value: True
+            - Name: ECDHE-ECDSA-AES256-GCM-SHA384
+              Value: True
+            - Name: ECDHE-RSA-AES256-GCM-SHA384
+              Value: True
+          PolicyType: SSLNegotiationPolicyType
+          PolicyName: SASRestrictedSSL
       Listeners:
         - LoadBalancerPort: '443'
           Protocol:
@@ -1041,7 +1055,10 @@ Resources:
               - HasSSLCertificate
               - AppCookieStickinessPolicy
               - Ref: AWS::NoValue
-
+            - Fn::If:
+              - HasSSLCertificate
+              - SASRestrictedSSL
+              - Ref: AWS::NoValue
       CrossZone: true
       HealthCheck:
         Target: 'TCP:443'


### PR DESCRIPTION
- updated post deployment role to use new policy when converting to HTTPS listener
- updated deployment template to create security policy and assign it when preexisting ssl cert present.