### PR TITLE
(AWSVIYA-200) rabbitmq error workaround

### DIFF
--- a/scripts/sasnodes_prereqs.sh
+++ b/scripts/sasnodes_prereqs.sh
@@ -11,6 +11,9 @@ ANSIBLE_KEY="${NFS_MOUNT_POINT}/ansible_key/id_rsa.pub"
 NFS_SERVER=${NFS_SERVER:-ansible}
 READINESS_FLAG_FILE="${NFS_MOUNT_POINT}/readiness_flags/${HOST}"
 
+#sudo yum update -y
+sudo yum install systemd-219-62.el7
+echo "exclude=systemd*" | sudo tee -a /etc/yum.conf
 #
 # create mount dir
 #

--- a/templates/sas-viya.template.yaml
+++ b/templates/sas-viya.template.yaml
@@ -1234,7 +1234,7 @@ Resources:
             #!/bin/bash -e
             export PATH=$PATH:/usr/local/bin
             curl -O https://bootstrap.pypa.io/get-pip.py && python get-pip.py &> /dev/null
-            pip install awscli --ignore-installed six &> /dev/null
+            pip install awscli==1.15.83 --ignore-installed six &> /dev/null
             easy_install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
             cfn-init --stack ${AWS::StackName} --resource ViyaServices --configsets quickstart --region ${AWS::Region}
             # Signal the status from cfn-init
@@ -1302,7 +1302,7 @@ Resources:
             #!/bin/bash -e
             export PATH=$PATH:/usr/local/bin
             curl -O https://bootstrap.pypa.io/get-pip.py && python get-pip.py &> /dev/null
-            pip install awscli --ignore-installed six &> /dev/null
+            pip install awscli==1.15.83 --ignore-installed six &> /dev/null
             easy_install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
             cfn-init --stack ${AWS::StackName} --resource CASController --configsets quickstart --region ${AWS::Region}
             # Signal the status from cfn-init
@@ -1937,7 +1937,7 @@ Resources:
             }    
 
             export PATH=$PATH:/usr/local/bin:/opt/aws/bin
-            pip install awscli --ignore-installed six &> /dev/null
+            pip install awscli==1.15.83 --ignore-installed six &> /dev/null
             # remove pre-installed cfn bootstrap utilities
             yum -y remove aws-cfn-bootstrap
             hash -d /opt/aws/bin/cfn-init


### PR DESCRIPTION
- pinning systemd to lower version and excluding it from rpm/yum management.
    This should not be the final fix, but is a solid workaround at the moment it seems as it stops viya-ark or the install proper from making the change and will get QA enabled again.