### PR TITLE
AWSVIYA-232 Update Quick Start to support Viya 3.5

### DIFF
--- a/scripts/download_file_tree.sh
+++ b/scripts/download_file_tree.sh
@@ -18,7 +18,7 @@ set -e
 test -n $FILE_ROOT
 DOWNLOAD_DIR=/sas/install
 INSTALL_USER=$(whoami)
-COMMON_CODE_TAG=4ccbb7a9a466fdb7c7d1ca6b37a60909781a7ec9
+COMMON_CODE_TAG=7c7f8f888af3f9be4fcb1358ea009baec5d1129f
 
 echo Downloading from ${FILE_ROOT} as ${INSTALL_USER}
 

--- a/templates/sas-viya.template.yaml
+++ b/templates/sas-viya.template.yaml
@@ -1328,6 +1328,8 @@ Resources:
         Fn::Base64:
           Fn::Sub: |
             #!/bin/bash -e
+            setenforce 0
+            sed -i.bak -e 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/selinux/config
             export PATH=$PATH:/usr/local/bin
             curl -O https://bootstrap.pypa.io/get-pip.py && python get-pip.py &> /dev/null
             pip install awscli==1.15.83 --ignore-installed six &> /dev/null

--- a/templates/sas-viya.template.yaml
+++ b/templates/sas-viya.template.yaml
@@ -1096,6 +1096,14 @@ Resources:
       FromPort: 0
       ToPort: 65535
       SourceSecurityGroupId: !Ref ViyaSecurityGroup
+  ViyatoviyaICMPIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref ViyaSecurityGroup
+      IpProtocol: icmp
+      FromPort: -1
+      ToPort: -1
+      SourceSecurityGroupId: !Ref ViyaSecurityGroup
 
 
 

--- a/templates/subtemplates/sas-viya.casworker.template.yaml
+++ b/templates/subtemplates/sas-viya.casworker.template.yaml
@@ -131,6 +131,8 @@ Resources:
         Fn::Base64:
           Fn::Sub: |
             #!/bin/bash -e
+            setenforce 0
+            sed -i.bak -e 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/selinux/config
             export PATH=$PATH:/usr/local/bin
             curl -O https://bootstrap.pypa.io/get-pip.py && python get-pip.py &> /dev/null
             pip install awscli==1.15.83 --ignore-installed six &> /dev/null


### PR DESCRIPTION
This commit contains updates to support Viya 3.5:

AWSVIYA-249 Add icmp ingress permissions to the ViyaSecurityGroup
AWSVIYA-250 Update AWS Quick Start to point to the latest common code
AWSVIYA-251 Set SELinux to Permissive on viya nodes