### PR TITLE
(AWSVIYA-257) Fix recover_cascontroller.sh

### DIFF
--- a/scripts/recover_cascontroller.sh
+++ b/scripts/recover_cascontroller.sh
@@ -178,7 +178,7 @@ export ANSIBLE_CONFIG=/sas/install/common/ansible/playbooks/ansible.cfg
 ansible-playbook -v /sas/install/common/ansible/playbooks/prepare_nodes.yml \
   -e "USERLIB_DISK=/dev/sdl" \
   -e "SAS_INSTALL_DISK=/dev/sdg" \
-  -l ${SERVER_NAME_IN_INVENTORY}
+  -l "${SERVER_NAME_IN_INVENTORY},AnsibleController"
 
 
 #


### PR DESCRIPTION
Add AnsibleController to the limit list for the prepare_nodes playbook, otherwise
the new CAS instance can still be in the process of initializing when the playbook
tries to run scripts on it. This is because the "wait_for_viya_vms" task will not
run unless the AnsibleController is in the limit list along with the new CAS
controller.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
